### PR TITLE
Added docker container to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This integration allows you to monitor and control servers that support IPMI.
 It can connect to your servers in three ways:
 - via the `ipmi-server` addon from [here](https://github.com/ateodorescu/home-assistant-addons) which is
     basically a wrapper for `ipmitool`.
-- via the `ipmi-server` docker container. See [mneveroff/ipmi-server](https://hub.docker.com/repository/docker/mneveroff/ipmi-server), for instructions. This is basically a wrapped [ipmi-server](https://github.com/ateodorescu/home-assistant-addons) add-on from the previous option
+- via the `ipmi-server` docker container. See [mneveroff/ipmi-server](https://hub.docker.com/repository/docker/mneveroff/ipmi-server), for instructions. This is basically a wrapped [ipmi-server](https://github.com/ateodorescu/home-assistant-addons) add-on from the previous option.
 - via the Python library [python-ipmi](https://github.com/kontron/python-ipmi)
 which hasn't been tested with all servers.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ hardware-based platform management systems that makes it possible to control and
 
 ## Home Assistant integration
 This integration allows you to monitor and control servers that support IPMI.
-It can connect to your servers in two ways:
+It can connect to your servers in three ways:
 - via the `ipmi-server` addon from [here](https://github.com/ateodorescu/home-assistant-addons) which is
     basically a wrapper for `ipmitool`.
+- via the `ipmi-server` docker container. See [mneveroff/ipmi-server](https://hub.docker.com/repository/docker/mneveroff/ipmi-server), for instructions. This is basically a wrapped [ipmi-server](https://github.com/ateodorescu/home-assistant-addons) add-on from the previous option
 - via the Python library [python-ipmi](https://github.com/kontron/python-ipmi)
 which hasn't been tested with all servers.
+
 
 If the `ipmi-server` addon is installed and started then this will be primarily used,
 and then it will fall back to the Python library if the addon is not reachable.


### PR DESCRIPTION
The idea is to refer the docker container that wraps `ipmi-server` that @ateodorescu wrote and provides it as a simple docker hub image, saving time and effort on building it on one's own.