### PR TITLE
Fix python-ipmi compatibility and improve config validation

### DIFF
--- a/custom_components/ipmi/config_flow.py
+++ b/custom_components/ipmi/config_flow.py
@@ -81,8 +81,15 @@ _LOGGER = logging.getLogger(__name__)
 
 def _validate_kg_key(value: str) -> str:
     """Validate the Kg key is valid hex and proper length."""
-    if not value:
-        return value
+    # Handle non-string types gracefully
+    if value is None:
+        return ""
+    # Convert to string if not already
+    if not isinstance(value, str):
+        value = str(value)
+    # Handle empty or whitespace-only strings
+    if not value.strip():
+        return ""
     # Remove any whitespace
     value = value.strip()
     # Must be even number of hex characters (valid octets)
@@ -128,9 +135,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     
     # Validate Kg key if provided
     kg_key = data.get(CONF_KG_KEY, "")
-    if kg_key:
-        kg_key = _validate_kg_key(kg_key)
-        data[CONF_KG_KEY] = kg_key
+    kg_key = _validate_kg_key(kg_key)
+    data[CONF_KG_KEY] = kg_key
 
     ipmi_data = IpmiServer(
         hass, 

--- a/custom_components/ipmi/server.py
+++ b/custom_components/ipmi/server.py
@@ -124,13 +124,13 @@ class IpmiServer:
             if self._addon_interface is not None and self._addon_interface != "auto":
                 params["interface"] = self._addon_interface
 
-            if self._kg_key is not None and self._kg_key != "":
+            if self._kg_key:
                 params["kg_key"] = self._kg_key
 
-            if self._privilege_level is not None and self._privilege_level != "":
+            if self._privilege_level:
                 params["privilege_level"] = self._privilege_level
 
-            if self._addon_extra_params is not None and self._addon_extra_params != "":
+            if self._addon_extra_params:
                 params["extra"] = self._addon_extra_params
 
             url = self._addon_url
@@ -261,22 +261,13 @@ class IpmiServer:
         ipmi.session.set_session_type_rmcp(self._host, self._port)
         ipmi.session.set_auth_type_user(self._username, self._password)
         
-        # Set Kg key if provided (for encrypted connections)
-        if self._kg_key and self._kg_key != "":
-            # Convert hex string to bytes for pyipmi (ipmitool uses hex string directly via -y flag)
-            kg_bytes = bytes.fromhex(self._kg_key)
-            ipmi.session.set_kg(kg_bytes)
+        # Note: python-ipmi library does not support Kg keys - only ipmi-server addon supports this
+        if self._kg_key:
+            _LOGGER.warning("Kg key specified but python-ipmi library does not support Kg key authentication. Kg key will be ignored. Consider using the ipmi-server addon for full feature support.")
         
         # Set privilege level if provided
-        if self._privilege_level and self._privilege_level != "":
-            # Map privilege level string to pyipmi constant
-            privilege_map = {
-                "ADMINISTRATOR": 4,
-                "OPERATOR": 3,
-                "USER": 2,
-            }
-            priv_level = privilege_map.get(self._privilege_level, 4)  # Default to ADMINISTRATOR
-            ipmi.session.set_priv_level(priv_level)
+        if self._privilege_level:
+            ipmi.session.set_priv_level(self._privilege_level)
         
         ipmi.session.establish()
         ipmi.target = pyipmi.Target(ipmb_address=0x20)

--- a/custom_components/ipmi/strings.json
+++ b/custom_components/ipmi/strings.json
@@ -15,6 +15,9 @@
           "addon_port": "[%key:common::config_flow::data::addon_port%]",
           "addon_interface": "[%key:common::config_flow::data::addon_interface%]",
           "addon_extra_params": "[%key:common::config_flow::data::addon_extra_params%]"
+        },
+        "data_description": {
+          "kg_key": "Optional. This feature requires the ipmi-server addon backend and is not supported by the python-ipmi library."
         }
       }
     },

--- a/custom_components/ipmi/translations/de.json
+++ b/custom_components/ipmi/translations/de.json
@@ -22,6 +22,9 @@
                     "addon_interface": "Addon-Schnittstellentyp für ipmitool",
                     "addon_extra_params": "Zusätzliche Addon-Parameter für ipmitool (vielleicht Cypher?)"
                 },
+                "data_description": {
+                    "kg_key": "Optional. Diese Funktion erfordert das ipmi-server-Addon-Backend und wird von der python-ipmi-Bibliothek nicht unterstützt."
+                },
                 "title": "Mit dem IPMI Server verbinden"
             }
         }

--- a/custom_components/ipmi/translations/el.json
+++ b/custom_components/ipmi/translations/el.json
@@ -22,6 +22,9 @@
                     "addon_interface": "Διεπαφή του πρόσθετου για το ipmitool",
                     "addon_extra_params": "Πρόσθετες παράμετροι του πρόσθετου για το ipmitool (cypher ίσως;)"
                 },
+                "data_description": {
+                    "kg_key": "Προαιρετικό. Αυτή η λειτουργία απαιτεί το backend του πρόσθετου ipmi-server και δεν υποστηρίζεται από τη βιβλιοθήκη python-ipmi."
+                },
                 "title": "Σύνδεση στον IPMI διακομιστή"
             }
         }

--- a/custom_components/ipmi/translations/en.json
+++ b/custom_components/ipmi/translations/en.json
@@ -22,6 +22,9 @@
                     "addon_interface": "Addon interface type for ipmitool",
                     "addon_extra_params": "Addon extra params for ipmitool (cypher maybe?)"
                 },
+                "data_description": {
+                    "kg_key": "Optional. This feature requires the ipmi-server addon backend and is not supported by the python-ipmi library."
+                },
                 "title": "Connect to the IPMI server"
             }
         }

--- a/custom_components/ipmi/translations/fr.json
+++ b/custom_components/ipmi/translations/fr.json
@@ -22,6 +22,9 @@
                     "addon_interface": "Type d'interface de l'addon pour ipmitool",
                     "addon_extra_params": "Paramètres supplémentaires de l'addon pour ipmitool (par ex. chiffrement)"
                 },
+                "data_description": {
+                    "kg_key": "Optionnel. Cette fonctionnalité nécessite le backend de l'add-on ipmi-server et n'est pas prise en charge par la bibliothèque python-ipmi."
+                },
                 "title": "Se connecter au serveur IPMI"
             }
         }


### PR DESCRIPTION
Key changes:
- Fix crash in config flow by improving Kg key validation to handle None/empty values gracefully
- Fix 'int' object has no attribute 'lower' error in python-ipmi by correcting privilege level handling (removed unnecessary mapping)
- Remove unsupported Kg key setting code for python-ipmi backend (not supported by library)
- Add warning log when Kg key is provided but python-ipmi backend is used
- Add UI notice to config flow explaining that Kg key requires ipmi-server addon (updated en, de, el, fr translations)
- Clean up redundant checks and simplify parameter handling in server.py