### PR TITLE
Reduce error logging in case the server is not available

### DIFF
--- a/custom_components/ipmi/server.py
+++ b/custom_components/ipmi/server.py
@@ -259,7 +259,7 @@ class IpmiServer:
 
         # except (IpmiConnectionError, ConnectionResetError) as err:
         except Exception as err:  # pylint: disable=broad-except
-            _LOGGER.error("Error connecting to IPMI server %s: %s", self._host, err)
+            _LOGGER.debug("Error connecting to IPMI server %s: %s", self._host, err)
             json = None
 
         return json


### PR DESCRIPTION
If one or more IPMI servers are not available, the log will be flooded with according log messages.
They are somewhat redundant, since the integration will also show a "Failed setup, will retry: Error fetching IPMI state" message for these servers.

This PR changes the severity to debug, s.t. they won't show up in the error log.

<img width="826" height="22" alt="Screenshot 2026-01-09 at 11 07 40" src="https://github.com/user-attachments/assets/de3d2645-8172-47dc-94cb-02b5a21c4318" />
