### PR TITLE
Address unique_id issue #69 + follow up on #72 (force switch id to lower case)

### DIFF
--- a/custom_components/ipmi/sensor.py
+++ b/custom_components/ipmi/sensor.py
@@ -79,7 +79,7 @@ async def async_setup_entry(
     if ipmiserver:
         coordinator = ipmiserver[COORDINATOR]
         data = ipmiserver[IPMI_DATA]
-        unique_id = ipmiserver[IPMI_UNIQUE_ID]
+        unique_id = (server_id + "_" + ipmiserver[IPMI_UNIQUE_ID]).lower()
 
         async_add_entities(
             [

--- a/custom_components/ipmi/sensor.py
+++ b/custom_components/ipmi/sensor.py
@@ -122,7 +122,7 @@ def create_entity_sensors(
 ) -> None:
     coordinator = ipmi_data[COORDINATOR]
     data = ipmi_data[IPMI_DATA]
-    unique_id = ipmi_data[IPMI_UNIQUE_ID]
+    unique_id = (server_id + "_" + ipmiserver[IPMI_UNIQUE_ID]).lower()
     status = coordinator.data
     entities = []
 
@@ -145,6 +145,7 @@ def create_entity_sensors(
                             state_class=SensorStateClass.MEASUREMENT,
                             # entity_category=EntityCategory.DIAGNOSTIC,
                             entity_registry_enabled_default=True,
+                            suggested_display_precision=2,
                         ),
                         data,
                         unique_id,
@@ -168,6 +169,7 @@ def create_entity_sensors(
                             state_class=SensorStateClass.MEASUREMENT,
                             # entity_category=EntityCategory.DIAGNOSTIC,
                             entity_registry_enabled_default=True,
+                            suggested_display_precision=2,
                         ),
                         data,
                         unique_id,
@@ -237,6 +239,7 @@ def create_entity_sensors(
                             state_class=SensorStateClass.MEASUREMENT,
                             # entity_category=EntityCategory.DIAGNOSTIC,
                             entity_registry_enabled_default=True,
+                            suggested_display_precision=2,
                         ),
                         data,
                         unique_id,

--- a/custom_components/ipmi/switch.py
+++ b/custom_components/ipmi/switch.py
@@ -88,7 +88,7 @@ class IpmiSwitch(CoordinatorEntity[DataUpdateCoordinator[dict[str, str]]],Switch
         self.entity_description = switch_description
 
         device_name = data.name.title()
-        self.entity_id = "switch." + DOMAIN + "_" + data._alias + "_" + switch_description.key
+        self.entity_id = ("switch." + DOMAIN + "_" + data._alias + "_" + switch_description.key).lower()
         self._attr_unique_id = f"{unique_id}_{switch_description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)},


### PR DESCRIPTION
* address unique_id issue mentioned in #69
* address switch entity_id naming convention (forcing lower case)
* set suggested_display_precision to 2 for temperature, voltage, current