### PR TITLE
Improved unique_id handling + suggested precision added to voltage+current sensors

### DIFF
--- a/custom_components/ipmi/__init__.py
+++ b/custom_components/ipmi/__init__.py
@@ -166,18 +166,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     server_id = entry.entry_id
 
     hass_data = get_ipmi_data(hass)
-    hass_data[SERVERS][entry.entry_id] = {
+    hass_data[SERVERS][server_id] = {
         COORDINATOR: coordinator,
         IPMI_DATA: data,
-        IPMI_UNIQUE_ID: server_id,
+        IPMI_UNIQUE_ID: server_id.lower(),
         USER_AVAILABLE_COMMANDS: INTEGRATION_SUPPORTED_COMMANDS,
     }
     hass_data[DISPATCHERS].setdefault(server_id, [])
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, server_id)},
+        config_entry_id=server_id,
+        identifiers={(DOMAIN, server_id.lower())},
         name=data.name.title(),
         manufacturer=data._device_info.device["manufacturer_name"],
         model=data._device_info.device["product_name"],

--- a/custom_components/ipmi/sensor.py
+++ b/custom_components/ipmi/sensor.py
@@ -80,7 +80,6 @@ async def async_setup_entry(
         coordinator = ipmiserver[COORDINATOR]
         data = ipmiserver[IPMI_DATA]
         unique_id = ipmiserver[IPMI_UNIQUE_ID]
-
         async_add_entities(
             [
                 IpmiSensor(
@@ -102,7 +101,7 @@ async def async_setup_entry(
         @callback
         def async_new_sensors() -> None:
             """Set up IPMI sensors."""
-            create_entity_sensors(ipmiserver, async_add_entities)
+            create_entity_sensors(ipmiserver, unique_id, async_add_entities)
 
         get_ipmi_data(hass)[DISPATCHERS][server_id].append(
             async_dispatcher_connect(
@@ -118,11 +117,11 @@ async def async_setup_entry(
 @callback
 def create_entity_sensors(
     ipmi_data: object,
+    unique_id: str,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = ipmi_data[COORDINATOR]
     data = ipmi_data[IPMI_DATA]
-    unique_id = ipmi_data[IPMI_UNIQUE_ID]
     status = coordinator.data
     entities = []
 
@@ -168,6 +167,7 @@ def create_entity_sensors(
                             state_class=SensorStateClass.MEASUREMENT,
                             # entity_category=EntityCategory.DIAGNOSTIC,
                             entity_registry_enabled_default=True,
+                            suggested_display_precision=2,
                         ),
                         data,
                         unique_id,
@@ -237,6 +237,7 @@ def create_entity_sensors(
                             state_class=SensorStateClass.MEASUREMENT,
                             # entity_category=EntityCategory.DIAGNOSTIC,
                             entity_registry_enabled_default=True,
+                            suggested_display_precision=2,
                         ),
                         data,
                         unique_id,
@@ -288,7 +289,7 @@ class IpmiSensor(
         self.entity_description = sensor_description
 
         device_name = data.name.title()
-        self._attr_unique_id = f"{unique_id}_{sensor_description.key}"
+        self._attr_unique_id = f"{unique_id}_{data._alias}_{sensor_description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)},
             name=device_name,

--- a/custom_components/ipmi/switch.py
+++ b/custom_components/ipmi/switch.py
@@ -88,8 +88,9 @@ class IpmiSwitch(CoordinatorEntity[DataUpdateCoordinator[dict[str, str]]],Switch
         self.entity_description = switch_description
 
         device_name = data.name.title()
-        self.entity_id = "switch." + DOMAIN + "_" + data._alias + "_" + switch_description.key
-        self._attr_unique_id = f"{unique_id}_{switch_description.key}"
+
+        self.entity_id = ("switch." + DOMAIN + "_" + data._alias + "_" + switch_description.key).lower()
+        self._attr_unique_id = f"{unique_id}_{data._alias}_{switch_description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)},
             name=device_name,


### PR DESCRIPTION
* tested locally in my HA installation. I didn't see any unique_id errors "yet"... not 100% sure it is solved though.
* this change does change unique_ids, entity_ids should stay the same except for the switch.
* new device for same server may show up when IMPI Connector is updated -- this can be addressed by re-adding the server