### PR TITLE
Never forget known sensors when a poll returns no readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Sensors that drop out of a poll (host powered off, BMC returning no readings) are no longer announced as new when they reappear, which re-created entities with existing unique IDs and logged `Platform ipmi does not generate unique IDs` on every power cycle
+
 ## 1.22.1 — 2026-08-17
 
 ### Fixed

--- a/custom_components/ipmi/server.py
+++ b/custom_components/ipmi/server.py
@@ -639,19 +639,21 @@ class IpmiServer:
 
         if info is not None:
             sensor_ids = iter_discovered_sensor_ids(info.sensors, info.states)
-            if not sensor_ids:
-                self._known_sensors.clear()
-            else:
-                self._known_sensors.intersection_update(sensor_ids)
-                new_sensors = [
-                    sensor_id
-                    for sensor_id in sensor_ids
-                    if sensor_id not in self._known_sensors
-                ]
-                if new_sensors:
-                    dispatcher_send(
-                        self.hass, IPMI_NEW_SENSOR_SIGNAL.format(self._entry_id)
-                    )
+            # _known_sensors tracks sensor ids that already have entities. It
+            # must only ever grow: entities are never removed at runtime, so a
+            # sensor that drops out of a poll (host powered off, BMC returning
+            # no readings) and later reappears must NOT be announced as new,
+            # or the platform re-creates an entity whose unique_id already
+            # exists ("Platform ipmi does not generate unique IDs").
+            new_sensors = [
+                sensor_id
+                for sensor_id in sensor_ids
+                if sensor_id not in self._known_sensors
+            ]
+            if new_sensors:
+                dispatcher_send(
+                    self.hass, IPMI_NEW_SENSOR_SIGNAL.format(self._entry_id)
+                )
 
     def is_known_sensor(self, sensor_id: str) -> bool:
         """Return True if this sensor id already has an entity."""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -551,3 +551,86 @@ class TestIpmiServerLogic:
         assert result is not None
         assert result["power_on"] is False
         mock_ipmi.get_fru_inventory.assert_not_called()
+
+    # --- known-sensor tracking across polls -------------------------------
+
+    def _addon_payload(self, sensors: dict, states: dict) -> dict:
+        return {
+            "success": True,
+            "power_on": bool(states),
+            "device": {},
+            "sensors": sensors,
+            "states": states,
+            "statuses": {},
+        }
+
+    def _poll(self, srv, payload: dict, announce: MagicMock) -> None:
+        with (
+            patch.object(srv, "_probe_addon_meta", return_value=None),
+            patch.object(srv, "get_from_addon", return_value=payload),
+            patch.object(self._server_mod, "dispatcher_send", announce),
+        ):
+            srv.update()
+
+    def test_known_sensors_survive_empty_poll(self) -> None:
+        """A poll with no readings (host powered off) must not forget sensors.
+
+        Entities are never removed at runtime, so announcing an already
+        created sensor as "new" again makes the sensor platform re-create
+        an entity with an existing unique_id.
+        """
+        srv = self._make_server(backend_preference="addon")
+        announce = MagicMock()
+        full = self._addon_payload(
+            {"temperature": {"temp_cpu": "CPU Temp"}}, {"temp_cpu": "41"}
+        )
+        empty = self._addon_payload({}, {})
+
+        self._poll(srv, full, announce)
+        assert announce.call_count == 1
+        # The sensor platform reacts to the signal and creates the entity.
+        srv.add_known_sensor("temp_cpu")
+
+        self._poll(srv, empty, announce)
+        assert srv.is_known_sensor("temp_cpu")
+
+        self._poll(srv, full, announce)
+        assert srv.is_known_sensor("temp_cpu")
+        assert announce.call_count == 1
+
+    def test_known_sensors_survive_partial_poll(self) -> None:
+        """A sensor missing from one poll is still known when it returns."""
+        srv = self._make_server(backend_preference="addon")
+        announce = MagicMock()
+        both = self._addon_payload(
+            {"temperature": {"temp_cpu": "CPU Temp"}, "fan": {"fan1": "FAN1"}},
+            {"temp_cpu": "41", "fan1": "900"},
+        )
+        only_fan = self._addon_payload({"fan": {"fan1": "FAN1"}}, {"fan1": "900"})
+
+        self._poll(srv, both, announce)
+        assert announce.call_count == 1
+        srv.add_known_sensor("temp_cpu")
+        srv.add_known_sensor("fan1")
+
+        self._poll(srv, only_fan, announce)
+        self._poll(srv, both, announce)
+        assert srv.is_known_sensor("temp_cpu")
+        assert announce.call_count == 1
+
+    def test_genuinely_new_sensor_is_announced(self) -> None:
+        """Discovery of a sensor never seen before still fires the signal."""
+        srv = self._make_server(backend_preference="addon")
+        announce = MagicMock()
+        one = self._addon_payload(
+            {"temperature": {"temp_cpu": "CPU Temp"}}, {"temp_cpu": "41"}
+        )
+        two = self._addon_payload(
+            {"temperature": {"temp_cpu": "CPU Temp", "temp_mb": "MB Temp"}},
+            {"temp_cpu": "41", "temp_mb": "35"},
+        )
+
+        self._poll(srv, one, announce)
+        srv.add_known_sensor("temp_cpu")
+        self._poll(srv, two, announce)
+        assert announce.call_count == 2


### PR DESCRIPTION
Fixes #87.

## Problem

`IpmiServer.update()` cleared `_known_sensors` when a poll returned no readings and pruned it on partial polls. The integration never removes entities at runtime, so when the readings came back (host powered on again) every sensor was announced via `IPMI_NEW_SENSOR_SIGNAL` and `create_entity_sensors()` re-created entities whose `unique_id` already existed:

```
Platform ipmi does not generate unique IDs. ID <entry>_<alias>_<key> already exists - ignoring sensor.<…>
```

— once per dynamic sensor, on every power cycle of the monitored host.

## Change

- `server.py`: `_known_sensors` is now monotonic for the lifetime of the entry. The "any discovered id not yet known → signal" check is kept; the `clear()` / `intersection_update()` are removed. Startup discovery (the set starts empty each run) and late discovery of genuinely new sensors behave exactly as before.
- `tests/test_util.py`: three tests in `TestIpmiServerLogic` driving `update()` through the addon backend with `dispatcher_send` mocked:
  - `test_known_sensors_survive_empty_poll` — fails on `main`, passes here
  - `test_known_sensors_survive_partial_poll` — fails on `main`, passes here
  - `test_genuinely_new_sensor_is_announced` — guards the preserved behaviour
- `CHANGELOG.md`: Unreleased → Fixed entry.

`pytest -q tests`: 74 passed.

## Notes

No entity ids, unique ids, or options change. Nothing else reads `_known_sensors`, so nothing depended on it shrinking.
